### PR TITLE
[Feat] Set profile view and my badge view interaction

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -2,13 +2,19 @@
 
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import MainView from './pages/mainView/MainPage';
+import MainView from './pages/MyBadgesSetting';
+import Profile from './pages/Profile';
+import MyBadges from './pages/MyBadges';
+import MyBadgesSetting from './pages/MyBadgesSetting';
 
 const Router = () => {
     return (
         <BrowserRouter>
             <Routes>
                 <Route path="/" element={<MainView />} />
+                <Route path="/profile" element={<Profile />} />
+                <Route path="/badge" element={<MyBadges />} />
+                <Route path="/badge/setting" element={<MyBadgesSetting />} />
             </Routes>
         </BrowserRouter>
     );

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,6 +4,7 @@ import ProfileIconDump from '../assets/images/ProfileRed.svg';
 import NavigationBar from './NavigationBar';
 import Divider from './Divider';
 import PageTitle from './PageTitle';
+import { Link } from 'react-router-dom';
 
 // Header
 /**
@@ -22,11 +23,13 @@ const Header = ({
             <div className="header">
                 <div className="service-name">
                     Koreasy
-                    <img
-                        src={ProfileIcon}
-                        alt="Profile"
-                        className="profile-icon"
-                    />
+                    <Link to="/profile">
+                        <img
+                            src={ProfileIcon}
+                            alt="Profile"
+                            className="profile-icon"
+                        />
+                    </Link>
                 </div>
             </div>
 

--- a/src/components/NavigationBar.jsx
+++ b/src/components/NavigationBar.jsx
@@ -1,18 +1,24 @@
 import React from 'react';
 import Chevron from './Chevrion';
 import './NavigationBar.scss';
+import { Link, useNavigate } from 'react-router-dom';
 
 // Navigation Bar
 /**
  * @param {string | undefined} [viewName=PreviousView] viewName Navigation Bar에 들어갈 Page View Name
  */
 const NavigationBar = ({ viewName = 'PreviousView' }) => {
+    let navigate = useNavigate();
+    const onPreviousViewClick = () => {
+        navigate(-1);
+    };
+
     return (
         <div className="previous-view">
-            <div className="text">
+            <span className="text" onClick={onPreviousViewClick}>
                 <Chevron direction="Left" color="MainColor" />
                 {viewName}
-            </div>
+            </span>
             <div className="dump-box" />
         </div>
     );

--- a/src/components/NavigationBar.scss
+++ b/src/components/NavigationBar.scss
@@ -11,9 +11,9 @@
     align-items: center;
 
     .text {
+        align-items: center;
         display: flex;
         height: 22px;
-        align-items: center;
         gap: 12px;
     }
 

--- a/src/pages/MyBadges.jsx
+++ b/src/pages/MyBadges.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Header from '../components/Header';
 import BadgeGroup from '../components/BadgeGroup';
 import '../styles/MyBadge.scss';
+import { Link } from 'react-router-dom';
 
 function MyBadgesView() {
     let dumpBadge = [
@@ -72,9 +73,9 @@ function MyBadgesView() {
                 }}
             />
             <div className="my-badge-button-group">
-                <button className="my-badge-button">
+                <Link to="/badge/setting" className="my-badge-button">
                     Set my signiture badge
-                </button>
+                </Link>
             </div>
         </div>
     );

--- a/src/pages/MyBadgesSetting.jsx
+++ b/src/pages/MyBadgesSetting.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Header from '../components/Header';
 import BadgeGroup from '../components/BadgeGroup';
 import '../styles/MyBadge.scss';
+import { Link } from 'react-router-dom';
 
 function MyBadgesViewSetting() {
     return (
@@ -9,8 +10,12 @@ function MyBadgesViewSetting() {
             <Header isNavigationBar={true} viewName="My Badges" />
             <BadgeGroup badges={[]} />
             <div className="my-badge-button-group">
-                <button className="my-badge-button cancel">Cancel</button>
-                <button className="my-badge-button">Confirm</button>
+                <Link to="/badge" className="my-badge-button cancel">
+                    Cancel
+                </Link>
+                <Link to="/badge" className="my-badge-button">
+                    Confirm
+                </Link>
             </div>
         </div>
     );

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -6,6 +6,7 @@ import '../styles/MyBadge.scss';
 import ProfileButton from '../components/ProfileButton';
 import BadgeGroup from '../components/BadgeGroup';
 import Chevrion from '../components/Chevrion';
+import { Link } from 'react-router-dom';
 
 function ProfileView() {
     let dumpProfile = {
@@ -87,7 +88,9 @@ function ProfileView() {
                     <div className={'my-badge-title'}>
                         <h2>My Badge</h2>
                         <div className={'my-badge-right-arrow-icon'}>
-                            <Chevrion direction='Right' color='MainColor' />
+                            <Link to="/badge">
+                                <Chevrion direction="Right" color="MainColor" />
+                            </Link>
                         </div>
                     </div>
                     <BadgeGroup badges={dumpProfile.badges} />

--- a/src/styles/MyBadge.scss
+++ b/src/styles/MyBadge.scss
@@ -8,12 +8,13 @@ div.my-badge-button-group {
     padding: 32px 20px 0 20px;
     width: 100%;
 
-    button.my-badge-button {
+    .my-badge-button {
         border-radius: 12px;
         border: none;
         background: $koreasy-color-primary;
         color: $koreasy-color-white;
         padding: 8px 16px;
+        text-decoration: none;
         height: 52px;
         width: 100%;
 


### PR DESCRIPTION
## 관련 이슈
- closes #44

## 구현/변경 사항
- Profile Router 정의
- MyBadge, MyBadgeSetting Router 정의
- NavigationBar `Previous View` 기능 개발
- Header에 있는 프로필 기능 이동하도록 연결
- Profile - MyBadge 간 연결
- MyBadge - MyBadge 간 연결 (설정한 뱃지 값을 백엔드로 보내는 작업은 #45 에서 처리할 예정)

## 추가 공유 사항
- 기능 개발이기 때문에 스크린샷은 생략하였습니다.